### PR TITLE
Make provider work in virtual garden cluster

### DIFF
--- a/charts/falco-event-provider/templates/provider-configmap.yaml
+++ b/charts/falco-event-provider/templates/provider-configmap.yaml
@@ -15,3 +15,6 @@ data:
       port: {{ .Values.eventProvider.port }}
     healthz:
       port: {{ .Values.healthz.port }}
+    virtualGarden:
+      name: {{ .Values.eventProvider.virtualGarden.name }}
+      dnsName: {{ .Values.eventProvider.virtualGarden.dnsName }}

--- a/charts/falco-event-provider/templates/provider-deployment.yaml
+++ b/charts/falco-event-provider/templates/provider-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         networking.gardener.cloud/to-dns: allowed
         resources.gardener.cloud/managed-by: gardener
         networking.resources.gardener.cloud/to-postgres-tcp-5432: allowed
+        networking.resources.gardener.cloud/to-garden-virtual-garden-kube-apiserver-tcp-443: allowed
     spec:
       automountServiceAccountToken: false
       containers:

--- a/charts/falco-event-provider/templates/provider-namespace.yaml
+++ b/charts/falco-event-provider/templates/provider-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    networking.gardener.cloud/access-target-apiserver: allowed
+  name: {{ .Release.Namespace }}

--- a/charts/falco-event-provider/values.yaml
+++ b/charts/falco-event-provider/values.yaml
@@ -10,6 +10,9 @@ eventProvider:
   port: 3200
   tlsServer: false
   replicas: 2
+  virtualGarden:
+    name: "" # sap-landscape-dev
+    dnsName: virtual-garden-kube-apiserver
 
 postgres:
   user: gardener

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -52,6 +52,11 @@ func initConfig(configFile string, postgresPasswordFile string) (*database.Postg
 		viper.GetString("postgres.dbname"),
 	)
 
+	gardenauth.LandscapeConfigInstance = &gardenauth.LandscapeConfig{
+		Name:    viper.GetString("virtualGarden.name"),
+		DNSName: viper.GetString("virtualGarden.dnsName"),
+	}
+
 	return postgresConfig, auth.NewAuth()
 }
 
@@ -78,6 +83,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		gardenauth.TlSConfig = config.TLSClientConfig
 		dynamicGardenCluster, err := dynamic.NewForConfig(config)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
- set labels for creating network policies
- only use internal virtual garden api server address
- make landscape name and location of vitual api server configurable

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
