### PR TITLE
Dependabot combine prs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,15 @@ updates:
     interval: "weekly"
   labels:
   - kind/enhancement
+  groups:
+  # Group all version-updates, except Gardener. Gardener-components should receive their own PR this way. Security updates will
+  # also receive their own individual PRs.
+    non-gardener-dependencies:
+      applies-to: "version-updates"
+      patterns:
+      - "*"
+      exclude-patterns:
+      - "github.com/gardener*"
 - package-ecosystem: "docker"
   directory: "/"
   schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:
Combine Dependabot PRs but keep gardener PRs separate  
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
