### PR TITLE
Support Gardener cert-controller-manager for ingestor certificates optionally

### DIFF
--- a/charts/falco-event-provider/templates/provider-ingress.yaml
+++ b/charts/falco-event-provider/templates/provider-ingress.yaml
@@ -6,6 +6,11 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
     cert.gardener.cloud/purpose: managed
+{{- if .Values.eventProvider.gardenDNSProvider }}
+    cert.gardener.cloud/dnsrecord-provider-type: {{ .Values.eventProvider.gardenDNSProvider.type }}
+    cert.gardener.cloud/dnsrecord-secret-ref: {{ .Values.eventProvider.gardenDNSProvider.secretRef.namespace }}/{{ .Values.eventProvider.gardenDNSProvider.secretRef.name }}
+    cert.gardener.cloud/dnsrecord-class: garden
+{{- end }}
   labels:
     app: {{ .Values.name }}
   name: {{ .Values.name }}-ingress

--- a/charts/falco-event-provider/values.yaml
+++ b/charts/falco-event-provider/values.yaml
@@ -13,6 +13,13 @@ eventProvider:
   virtualGarden:
     name: "" # sap-landscape-dev
     dnsName: virtual-garden-kube-apiserver
+### The gardenDNSProvider section is needed if the garden-runtime cluster uses the garden cert-controller-manager
+### Values are from the `Garden` resource at `.spec.dns.providers[0]`
+# gardenDNSProvider:
+#   secretRef:
+#     namespace: garden
+#     name: garden-gardener-dns
+#   type: aws-route53
 
 postgres:
   user: gardener


### PR DESCRIPTION
**What this PR does / why we need it**:
If the Gardener runtime-cluster makes use of the runtime extension of the shoot-cert-service, (see [Providing Trusted TLS Certificate for Garden Runtime Cluster](https://github.com/gardener/gardener-extension-shoot-cert-service/blob/master/docs/operations/deployment.md#providing-trusted-tls-certificate-for-garden-runtime-cluster), the certificates must contain additional information about the DNS provider. This cert-controller-manager instance uses `DNSRecords` from the provider extensions and needs additional fields for the credentials.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Support Gardener cert-controller-manager for event provider certificates optionally.
```
