### PR TITLE
Support Gardener cert-controller-manager for ingestor certificates optionally (follow-up)

### DIFF
--- a/charts/falco-event-provider/templates/provider-ingress.yaml
+++ b/charts/falco-event-provider/templates/provider-ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
     cert.gardener.cloud/purpose: managed
 {{- if .Values.eventProvider.gardenDNSProvider }}
+    cert.gardener.cloud/class: garden
     cert.gardener.cloud/dnsrecord-provider-type: {{ .Values.eventProvider.gardenDNSProvider.type }}
     cert.gardener.cloud/dnsrecord-secret-ref: {{ .Values.eventProvider.gardenDNSProvider.secretRef.namespace }}/{{ .Values.eventProvider.gardenDNSProvider.secretRef.name }}
     cert.gardener.cloud/dnsrecord-class: garden


### PR DESCRIPTION
**What this PR does / why we need it**:
Missed to set the `cert.gardener.cloud/class` annotation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up of #128 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
