### PR TITLE
Adapt VPA resources to explicitly specify update mode `InPlaceOrRecreate`

### DIFF
--- a/charts/falco-event-provider/templates/provider-vpa.yaml
+++ b/charts/falco-event-provider/templates/provider-vpa.yaml
@@ -8,4 +8,4 @@ spec:
     kind: Deployment
     name: {{ .Values.name }}
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
The changes in this PR explicitly set the update mode of the VPA resources to InPlaceOrRecreate. Doing so will allow us to remove the GRM webhook in a future release, as it is currently unconditionally enabled.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12955

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```
The update mode of the VerticalPodAutoscaler resource, deployed by falco-event-provider, is now explicitly set to `InPlaceOrRecreate`, reflecting the actual runtime behavior after the unconditional enablement of the `VPAInPlaceUpdates` feature gate.
```
